### PR TITLE
Allow for gnutls to be managed via variable

### DIFF
--- a/files/rsyslog_default
+++ b/files/rsyslog_default
@@ -1,7 +1,7 @@
 # File is managed by puppet
 
 # Debian, Ubuntu
-RSYSLOGD_OPTIONS="-c4"
+RSYSLOGD_OPTIONS=""
 
 # CentOS, RedHat, Fedora
 SYSLOGD_OPTIONS="${RSYSLOGD_OPTIONS}"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,7 +25,7 @@ class rsyslog::install {
 
   if $rsyslog::ssl != false {
     package { 'rsyslog-gnutls':
-      ensure => present
+      ensure => $rsyslog::package_status
     }
  }
 


### PR DESCRIPTION
We also remove the -c4 flag as we don't need compatibility flags with version 7