### PR TITLE
Remove custom_config parameter

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -8,7 +8,6 @@
 # [*enable_udp*]
 # [*enable_onefile*]
 # [*server_dir*]
-# [*custom_config*]
 # [*high_precision_timestamps*]
 # [*ssl*]
 # [*ssl_ca*]
@@ -25,27 +24,17 @@
 #
 #  Create seperate directory per host
 #
-#  class { 'rsyslog::server':
-#    custom_config => 'rsyslog/server-hostname.conf.erb'
-#  }
-#
 class rsyslog::server (
   $enable_tcp                = true,
   $enable_udp                = true,
   $enable_onefile            = false,
   $server_dir                = '/srv/log',
-  $custom_config             = undef,
   $high_precision_timestamps = false,
   $ssl                       = false,
   $ssl_ca                    = undef,
   $ssl_cert                  = undef,
   $ssl_key                   = undef
 ) inherits rsyslog {
-
-  $real_content = $custom_config ? {
-    ''      => template("${module_name}/server-default.conf.erb"),
-    default => template($custom_config),
-  }
 
   rsyslog::snippet {'server':
     ensure  => present,


### PR DESCRIPTION
Remove the custom_config parameter on rsyslog::server

The case statement didn't work on Puppet 4.x because it only works if undef == ''. In puppet 4 this causes compiles to fail.

puppetlabs-modules doesn't use this parameter anyway, so it's easier to remove it entirely than to fix it. The newer version of saz-rsyslog uses a different implementation anyway, so if we ever upgrade to it this issue won't recur.