### PR TITLE
(bug) Fix content snipper for rsyslog server

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -38,6 +38,6 @@ class rsyslog::server (
 
   rsyslog::snippet {'server':
     ensure  => present,
-    content => $real_content,
+    content => template("${module_name}/server-default.conf.erb"),
   }
 }


### PR DESCRIPTION
37da48 causes the server config to become blank when removing the
real_content variable.  This puts a value back in place for the content
variable.

See #5 for what was removed.