### PR TITLE
Migrate default file to template.

### DIFF
--- a/files/rsyslog_default
+++ b/files/rsyslog_default
@@ -1,7 +1,0 @@
-# File is managed by puppet
-
-# Debian, Ubuntu
-RSYSLOGD_OPTIONS=""
-
-# CentOS, RedHat, Fedora
-SYSLOGD_OPTIONS="${RSYSLOGD_OPTIONS}"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,7 +34,7 @@ class rsyslog::config {
     ensure  => file,
     owner   => 'root',
     group   => $rsyslog::run_group,
-    source  => 'puppet:///modules/rsyslog/rsyslog_default',
+    content => template("${module_name}/rsyslog_default.erb"),
     require => Class['rsyslog::install'],
     notify  => Class['rsyslog::service'],
   }

--- a/templates/rsyslog_default.erb
+++ b/templates/rsyslog_default.erb
@@ -1,0 +1,10 @@
+# File is managed by puppet
+
+<% case @osfamily -%>
+<% when 'Debian' -%>
+# Debian, Ubuntu
+RSYSLOGD_OPTIONS=""
+<% when 'RedHat' -%>
+# CentOS, RedHat, Fedora
+SYSLOGD_OPTIONS=""
+<% end -%>


### PR DESCRIPTION
  This commit will move the rsyslog_default file to a template.

  This is required because systemd does understand variable
  interpolation.